### PR TITLE
Website running using php 8.2

### DIFF
--- a/evilness-filter.php
+++ b/evilness-filter.php
@@ -46,12 +46,13 @@ function removeEvilAttributes($tagSource)
 
 function myaddslashes($st)
 {
-    if (get_magic_quotes_gpc()) {
+    if (ini_get('magic_quotes_gpc')) {
         return $st;
     } else {
         return addslashes($st);
     }
 }
+
 
 function makeSafe($UnsafeSource)
 {


### PR DESCRIPTION
Function get_magic_quotes_gpc() deprecated was removed and function myaddslashes() was updated to run on php 8.2